### PR TITLE
fix bug in ss.find('0')

### DIFF
--- a/api/python/mvnc/mvncapi.py
+++ b/api/python/mvnc/mvncapi.py
@@ -187,7 +187,7 @@ class Device:
             for i in range(40):
                 if v.raw[i * 50] != 0:
                     ss = v.raw[i * 50:]
-                    end = ss.find(0)
+                    end = ss.find('0')
                     l.append(ss[0:end].decode())
             return l
         if opt == DeviceOption.THERMAL_STATS:


### PR DESCRIPTION
Solves:
opt = device.GetDeviceOption(mvnc.DeviceOption.OPTIMISATION_LIST)
  File "/usr/local/lib/python2.7/dist-packages/mvnc/mvncapi.py", line 190, in GetDeviceOption
    end = ss.find(0)
TypeError: expected a string or other character buffer object