### PR TITLE
Fix the crash when it is running on Android

### DIFF
--- a/api/src/mvnc_api.c
+++ b/api/src/mvnc_api.c
@@ -249,7 +249,7 @@ mvncStatus mvncOpenDevice(const char *name, void **deviceHandle)
 		free(temp);
 		return rc;
 	}
-	if (strlen(saved_name) > 0) {
+	if (saved_name && strlen(saved_name) > 0) {
 		device_name = strtok_r(NULL, ":", &saved_name);
 		second_name_available = 1;
 	}


### PR DESCRIPTION
When it is running on Android, saved_name will be NULL.