### PR TITLE
Aws workaround

### DIFF
--- a/docs/tools/check.md
+++ b/docs/tools/check.md
@@ -8,7 +8,7 @@ Revision|1.08
 See also| [mvNCCompile](compile.md), [mvNCProfile](profile.md), [TensorFlow™ Info](../TensorFlowUsage.md)
 
 ## Overview
-This command line tool validates (checks) a Caffe or TensorFlow™ neural network on the Intel® Movidius™ Neural Compute Stick (Intel® Movidius™ NCS.)  The check is done by running an inference on the NCS and also on the host computer in software using the supplied network and appropriate framework libraries.  The results for both inferences (NCS results vs. framework's expected results) are compared to determine a if the network passes or fails and the top 5 inference results are provided as output. 
+This command line tool validates (checks) a Caffe or TensorFlow™ nerual network on the Intel® Movidius™ Neural Compute Stick (Intel® Movidius™ NCS.)  The check is done by running an inference on the NCS and also on the host computer in software using the supplied network and appropriate framework libraries.  The results for both inferences (NCS results vs. framework's expected results) are compared to determine a if the network passes or fails and the top 5 inference results are provided as output. 
 
 
 ## Syntax
@@ -35,9 +35,9 @@ network.prototxt(caffe)<br>network.meta(TensorFlow™)|Name of the network file.
 [-o Output Graph Filename]|Default: "graph"<br><br>Output graph container filename. If not provided, “graph” will be used.
 [-i image filename]|Image to use as input to validation run.<br>If not set, a randomly generated image will be used.
 [-id Top-1 Validation ID]|Expected id for Top-1 validation.
-[-S scale factor]|Divisor used to scale each value of the input.<br>E.g., Typically images are stored with data for each input channel in the range from 0-255.  If using this tool with one of these typical images, and the neural network expects input values in the range 0.0 - 1.0, then -S 255 will scale the values to the network's expected range because each value will be divided by 255.  If the network expects values between -1.0 and 1.0 then -S 128 and -M 128 can be used.
-[-M Mean Subtraction Number or npy filename]|Subtract this value from the input prior to passing to the neural network.  If the network expects input values between -1.0 and 1.0 then -S 128 and -M 128 can be used.
-[-cs Color Sequence]|Color Sequence of Input channels the neural network expects:<br>  2,1,0: network expects BGR (Default) <br>  0,1,2 : network expects RGB
+[-S scale factor]|Scale each value of the input by this amount.<br>E.g., if the network expects input values in the range 0-255, put 255 here (1 is default, as the range 0-1 is the default).
+[-M Mean Subtraction Number or npy filename]|Subtract this from the input (applied after scale). E.g., if the network expects a mean file to be subtracted from the input image, put it here.
+[-cs Color Sequence]|Color Sequence of Input channels:<br>  2,1,0: BGR (Default) <br>  0,1,2 : RGB
 
 ## Known Issues
 

--- a/docs/tools/check.md
+++ b/docs/tools/check.md
@@ -8,7 +8,7 @@ Revision|1.08
 See also| [mvNCCompile](compile.md), [mvNCProfile](profile.md), [TensorFlow™ Info](../TensorFlowUsage.md)
 
 ## Overview
-This command line tool validates (checks) a Caffe or TensorFlow™ nerual network on the Intel® Movidius™ Neural Compute Stick (Intel® Movidius™ NCS.)  The check is done by running an inference on the NCS and also on the host computer in software using the supplied network and appropriate framework libraries.  The results for both inferences (NCS results vs. framework's expected results) are compared to determine a if the network passes or fails and the top 5 inference results are provided as output. 
+This command line tool validates (checks) a Caffe or TensorFlow™ neural network on the Intel® Movidius™ Neural Compute Stick (Intel® Movidius™ NCS.)  The check is done by running an inference on the NCS and also on the host computer in software using the supplied network and appropriate framework libraries.  The results for both inferences (NCS results vs. framework's expected results) are compared to determine a if the network passes or fails and the top 5 inference results are provided as output. 
 
 
 ## Syntax
@@ -35,9 +35,9 @@ network.prototxt(caffe)<br>network.meta(TensorFlow™)|Name of the network file.
 [-o Output Graph Filename]|Default: "graph"<br><br>Output graph container filename. If not provided, “graph” will be used.
 [-i image filename]|Image to use as input to validation run.<br>If not set, a randomly generated image will be used.
 [-id Top-1 Validation ID]|Expected id for Top-1 validation.
-[-S scale factor]|Scale each value of the input by this amount.<br>E.g., if the network expects input values in the range 0-255, put 255 here (1 is default, as the range 0-1 is the default).
-[-M Mean Subtraction Number or npy filename]|Subtract this from the input (applied after scale). E.g., if the network expects a mean file to be subtracted from the input image, put it here.
-[-cs Color Sequence]|Color Sequence of Input channels:<br>  2,1,0: BGR (Default) <br>  0,1,2 : RGB
+[-S scale factor]|Divisor used to scale each value of the input.<br>E.g., Typically images are stored with data for each input channel in the range from 0-255.  If using this tool with one of these typical images, and the neural network expects input values in the range 0.0 - 1.0, then -S 255 will scale the values to the network's expected range because each value will be divided by 255.  If the network expects values between -1.0 and 1.0 then -S 128 and -M 128 can be used.
+[-M Mean Subtraction Number or npy filename]|Subtract this value from the input prior to passing to the neural network.  If the network expects input values between -1.0 and 1.0 then -S 128 and -M 128 can be used.
+[-cs Color Sequence]|Color Sequence of Input channels the neural network expects:<br>  2,1,0: network expects BGR (Default) <br>  0,1,2 : network expects RGB
 
 ## Known Issues
 

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,8 @@ then
 	cd /tmp
 else
 	cd /tmp
-	wget --no-cache http://ncs-forum-uploads.s3.amazonaws.com/ncsdk/ncsdk_01_12/ncsdk_redirector.txt
+	#wget --no-cache http://ncs-forum-uploads.s3.amazonaws.com/ncsdk/ncsdk_01_12/ncsdk_redirector.txt
+	wget --no-cache -O ncsdk_redirector.txt "https://ncs-forum-uploads.s3-us-west-1.amazonaws.com/ncsdk/ncsdk_01_012_B/ncsdk_redirector.txt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAJPV7SAH5YZ2U3ARA/20180314/us-west-1/s3/aws4_request&X-Amz-Date=20180314T233615Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Signature=8886c9b49d0017ef736c9d226ff6763552f46fa501163fcbe769035c63b84456"
 fi
 
 download_filename=NCSDK-1.12.tar.gz


### PR DESCRIPTION
changed url for the redirector.txt file to a new file on the aws server that contains a new url which will be good until 2018-03-21.  

Suggesting this as a temporary workaround until the the aws issue is figured out - for some reason started getting permission denied from the server for same URLs that were working.   