### PR TITLE
Fix for failing docker build because of missing mvnc directory

### DIFF
--- a/api/src/Makefile
+++ b/api/src/Makefile
@@ -122,4 +122,4 @@ clean:
 	rm -f $(OBJS)
 	rm -rf $(OBJDIR)
 	rm -f $(LIB_NAME).so
-	find mvnc/ -type f -delete
+	rm -rf mvnc


### PR DESCRIPTION
When trying to build a Docker container using _extras/docker/Dockerfile_NoPreviligeAccess_, I'm getting the following error:
```
find: 'mvnc/': No such file or directory
make: *** [clean] Error 1
Makefile:121: recipe for target 'clean' failed
The command '/bin/sh -c sudo make clean && sudo make get_mvcmd && sudo make basicinstall NO_BOOT=yes NO_RESET=yes && sudo make pythoninstall' returned a non-zero code: 2
```
Fixing this by calling _rm -rf_ on mvnc instead of _find_.