### PR TITLE
Container quickfix

### DIFF
--- a/install-opencv.sh
+++ b/install-opencv.sh
@@ -98,24 +98,18 @@ function install_opencv()
         fi
     else  
         echo "Installing opencv python for non-Raspbian";
-        # check if pip2 & pip3 are available on the system via 'command'
+        # check if pip3 are available on the system via 'command'
         RC=0
         command -v pip3 > /dev/null || RC=$?
         if [ $RC -ne 0 ] ; then
             exec_and_search_errors "$SUDO_PREFIX apt-get $APT_QUIET update -y"
             exec_and_search_errors "$SUDO_PREFIX apt-get $APT_QUIET install -y python3-pip"
         fi
-        command -v pip2 > /dev/null || RC=$?
-        if [ $RC -ne 0 ] ; then
-            exec_and_search_errors "$SUDO_PREFIX apt-get $APT_QUIET install -y python-pip"
-        fi
 
         PIP_QUIET=--quiet
         [ "${VERBOSE}" = "yes" ] && PIP_QUIET=""
         exec_and_search_errors "$PIP_PREFIX pip3 install $PIP_QUIET opencv-python>=3.4.0.12"
         exec_and_search_errors "$PIP_PREFIX pip3 install $PIP_QUIET opencv-contrib-python>=3.4.0.12"
-        exec_and_search_errors "$PIP_PREFIX pip2 install $PIP_QUIET opencv-python>=3.4.0.12"
-        exec_and_search_errors "$PIP_PREFIX pip2 install $PIP_QUIET opencv-contrib-python>=3.4.0.12"
     fi
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,10 @@ scikit-image>=0.13.0,<=0.14.0
 scipy>=0.14.1,<=0.19.1
 six>=1.10.0
 networkx>=2.1,<=2.1
-pygraphviz>=1.3.1
+pygraphviz>=1.3.1,<=1.5
+# https://github.com/evilsocket/opensnitch/issues/275
+grpcio==1.24.0
 Enum34>=1.1.6
 numpy==1.15
+dask==2.4.0
+scikit-build==0.11.1


### PR DESCRIPTION
Occasionally I tried to build a container from source, using the [corresponding instruction](https://movidius.github.io/ncsdk/docker.html). It turned out that python packages now require new dependencies, and some of them don't work with Python 3.5, which is default for Ubuntu 16.04 LTS. Furthermore, commands like `make examples` don't work as well, requiring specific versions of packages. I reconfigured packages to make it work, and also had to drop Python2 support from `install-opencv.sh`.

But only after that I realized that now if I want to work with Movidius, [I should](https://community.intel.com/t5/Intel-Distribution-of-OpenVINO/NCSDK-vs-Open-VINO-Toolkit/td-p/667448) use [OpenVINO](https://software.intel.com/content/www/us/en/develop/articles/transitioning-from-intel-movidius-neural-compute-sdk-to-openvino-toolkit.html). It would be good to put a note about that on all pages of [NCSDK's instructions and docs](https://movidius.github.io/ncsdk/), because they are the first links in Google by "movidius docker" request.

I decided to show you my changes, just if at some time you decide to update this product. And anyway thanks for the tool :-)